### PR TITLE
Upgrade rake to version 12.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rake', '~> 10.0'
+gem 'rake', '~> 12.0'
 gem 'minitest'
 gem 'flowbyte-foo'


### PR DESCRIPTION
Hello,




We've upgraded a dependency and here is what you need to know:


| gem name | version specification  | new version |
| --- | --- | --- |
| rake | ~> 10.0 | 12.0.0 |


Please take a good look at the info here and the test results before merging this pull request.







---
[Depfu](https://depfu.io) sends automated pull requests to update your Ruby dependencies.

